### PR TITLE
Fix for Issue 1

### DIFF
--- a/src/oauth/util.clj
+++ b/src/oauth/util.clj
@@ -106,7 +106,7 @@
   [request]
   (if-let [body (:body request)]
     (let [body (if (byte-array? body) (String. body) (str body))]
-      (-> (apply hash-map (split body #"="))
+      (-> (apply hash-map (split body #"[=&]"))
           (transform-values url-decode)))))
 
 (defn percent-encode

--- a/test/oauth/test/util.clj
+++ b/test/oauth/test/util.clj
@@ -87,7 +87,9 @@
     twitter-update-status
     {"status" "Hello Ladies + Gentlemen, a signed OAuth request!"}
     (assoc twitter-update-status :body (.getBytes (:body twitter-update-status)))
-    {"status" "Hello Ladies + Gentlemen, a signed OAuth request!"}))
+    {"status" "Hello Ladies + Gentlemen, a signed OAuth request!"}
+    (assoc twitter-update-status :body "x=foo&y=bar")
+    {"x" "foo" "y" "bar"}))
 
 (deftest test-random-base64
   (is (string? (random-base64 1)))


### PR DESCRIPTION
Updates the regexp used for splitting form-encoded bodies so that it will work with more than one param.
