### PR TITLE
Add oauth-authorize-url function

### DIFF
--- a/src/oauth/v1.clj
+++ b/src/oauth/v1.clj
@@ -21,9 +21,14 @@
                                        (:query-params request))))
       (util/format-authorization)))
 
+(defn oauth-authorize-url
+  "Returns the authorization url"
+  [url oauth-token]
+  (format "%s?oauth_token=%s" url oauth-token))
+
 (defn oauth-authorize
   "Send the user to the authorization url via `browse-url`."
-  [url oauth-token] (browse-url (format "%s?oauth_token=%s" url oauth-token)))
+  [url oauth-token] (browse-url (oauth-authorize-url url oauth-token)))
 
 (defn oauth-signature-parameters
   "Returns the OAuth signature parameters from `request`."


### PR DESCRIPTION
Hi,

we need to access the oauth authorization URL as we are opening the login page in a pop up and browse-url is opening it in a new tab. 

I have extracted the function so that it can be called independently. 
I have not added any test for it as it's implicitly tested by test-oauth-authorize, but I am happy to add some if you feel necessary. 

Feel free to merge if it's of any use and thanks a lot for the library!
cheers