### PR TITLE
Address githubs' new access token format

### DIFF
--- a/src/oauth/v2.clj
+++ b/src/oauth/v2.clj
@@ -6,7 +6,12 @@
             [oauth.io :refer [request]]))
 
 (defn- update-access-token [request access-token]
-  (assoc-in request [:query-params "access_token"] access-token))
+  (assoc-in
+   (assoc-in
+    request
+    [:query-params "access_token"]
+    access-token)
+   [:headers "Authorization" (str "token " access-token)]))
 
 (defn oauth-access-token
   "Obtain the OAuth access token."


### PR DESCRIPTION
- As per https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
  we now need to send the access token as part of the `Authorization` header.

This commits sends _both_, because I'm not sure how widespread the change is, and still want this client to be compatible with OAuth providers other than `github`. Maybe a config option that defaults to `header` for `github` would be a better option?