### PR TITLE
Update V2 to fix error

### DIFF
--- a/src/oauth/v2.clj
+++ b/src/oauth/v2.clj
@@ -23,9 +23,9 @@
 
 (defn oauth-authorization-url
   "Returns the OAuth authorization url."
-  [url client-id redirect-uri & {:as options}]
-  (->> (assoc options :client-id client-id :redirect-uri redirect-uri)
-       (format-query-params)
+  [url client-id redirect-uri & options]
+  (->> (assoc (into {} options) :client-id client-id :redirect-uri redirect-uri)
+       format-query-params
        (str url "?")))
 
 (defn oauth-authorize


### PR DESCRIPTION
This was throwing an exception when trying to pass in any options––I created the error with {:response-type "code"}

It looks like it was not destructuring the parameter properly. There might be a more elegant way of fixing the error but this resolved it and shouldn't cause subsequent problems